### PR TITLE
Aliases support implemented

### DIFF
--- a/include/clicky.hpp
+++ b/include/clicky.hpp
@@ -60,6 +60,7 @@ private:
     std::vector<std::string> positional_args_;
 
     std::string join_values(const std::vector<std::string>& values) const;
+    int parse_field(std::string arg);
 
     void validate_required_arguments(); // Added
     size_t calculate_max_length() const; // Added


### PR DESCRIPTION
Hello!
I implemented the support of aliases.
Now, if testing on `examples/01.cpp` with aliases `-o` for `--output` and `-i` for `--input`, the following have the same meaning:
```
a.out --verbose --input inputfile --output outputfile
a.out -v -iinputfile -o outputfile
a.out -vinputfile -outputfile
```