### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
-.cache/
-dist/
-build/
-*.a
-*.so
-.clangd
-test
-/examples/Makefile
-/examples/executable
-/include/clicky
-
+# Files / Scripts
 release.sh
 tmux.sh
 dist.py
+examples/Makefile
+examples/executable
+include/clicky
+test
+
+# Directories
+dist/
+build/
+.cache/
+
+# Generated / Dotfiles
+*.a
+*.so
+.clangd
+.envrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ test
 /include/clicky
 
 release.sh
+tmux.sh
 dist.py
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
     <img src="https://github.com/auth-xyz/assets/blob/main/logos/chunky.png?raw=true" alt="logo" width="400" height="400">
 </p>
 
+----
+
 ### CLIcky
 
 **clicky** is a simple C++ library for handling command-line arguments and options. It allows you to define options and arguments, parse input, and display formatted help messages. You can easily add required or optional arguments, set default values for options, and access both positional and named arguments. The library supports aliases for options and arguments, ensures all required arguments are provided, and presents clear, color-coded help information for better usability.
@@ -44,56 +46,83 @@ Now I need to put this reminder here, whenever you use clicky, you *need* to pas
 So, I'll try to make this documentation concise and easy to digest.
 Below, you'll find a list of the methods that are under the public interface of `clicky`:
 
-`clicky::clicky()` - `constructor`
-- Takes a single (optional) `std::string` argument that is the usage of the program. The usage can have a builtin variable `{program}` which will be replaced with the argv[0].
+#### `clicky::clicky(std::string usage = "")` - **constructor**
+- Takes an optional `std::string` argument that is the usage message for the program. The usage can include the special variable `{program}`, which will be replaced with `argv[0]`.
+
+#### `clicky::add_argument(const std::string& name, const std::string& alias, const std::string& description, bool required)` - **method**
+- Adds a positional argument. Takes 4 arguments:
+  - `name`: The name of the argument.
+  - `alias`: The alias for the argument.
+  - `description`: A brief description of the argument.
+  - `required`: A boolean indicating whether the argument is required.
+
+  The `clicky::add_arguments()` method is a convenience method for adding multiple arguments at once.
+
+#### `clicky::add_option(const std::string& name, const std::string& alias, const std::string& description, bool required)` - **method**
+- Adds an option. Takes 4 arguments:
+  - `name`: The name of the option.
+  - `alias`: The alias for the option.
+  - `description`: A brief description of the option.
+  - `required`: A boolean indicating whether the option is required.
+
+  The `clicky::add_options()` method is a convenience method for adding multiple options at once.
+
+#### `clicky::set_prefix(const std::vector<std::string>& arg_prefixes, const std::vector<std::string>& option_prefixes)` - **method**
+- Sets prefixes for arguments and options. The `arg_prefixes` vector applies to argument prefixes, while `option_prefixes` applies to option prefixes. This allows you to customize how arguments and options are prefixed (e.g., using `-` or `/` for flags).
+
+#### `clicky::group(const std::string& group_name, const std::vector<std::string>& option_aliases)` - **method**
+- Groups options together. The `group_name` is the name of the group, and `option_aliases` is a vector of option aliases that belong to the group. Allows things like ./someprogram -xyz
+
+#### `clicky::parse(int argc, char* argv[])` - **method**
+- Parses the command-line arguments. It takes two arguments: `argc` and `argv` from the `main()` function.
 
 
-`clicky::add_argument(const std::string& name, const std::string& alias, bool required, const std::string& description)` - `method` 
-- Takes 4 arguments, the name of the argument, its alias, if its required or not, and the description of the argument. The `clicky::add_arguments()` method is a convenience method that allows you to add multiple arguments at once.
+---
 
+### Example Usage
 
-`clicky::add_option(const std::string& name, const std::string& alias, bool required, const std::string& description)` - `method` 
-- Takes 4 arguments, the name of the option, its alias, its default value (either true or false), and the description of the option. The `clicky::add_options()` method is a convenience method that allows you to add multiple options at once.
+#### Example 1: Simple Program with Arguments and Options
 
-`clicky::set_prefix(const std::vector<std::string>& arg_prefixes, const std::vector<std::string>& option_prefixes)` - `method`
-- Takes 2 arguments, the prefixes for arguments and options. See `examples/02.cpp` for a better understanding
-
-`clicky::parse(int argc, char* argv[])` - `method`
-- Takes 2 arguments, the argc and argv of the program. Does all the heavy lifting.
-
-
-
-An example of how you'd use clicky in action:
 ```cpp
 #include <clicky/clicky.hpp>
 
 int main(int argc, char* argv[]) {
-   clicky cli; // no usage message 
+    clicky cli; // no usage message 
 
-   cli.add_option("option", "f", false, "This is a option");
-   cli.add_argument("argument", "a", true, "This is an argument");
+    cli.add_option("option", "f", "This is an option", false);
+    cli.add_argument("argument", "a", "This is an argument", true);
 
-   cli.parse(argc, argv);
+    cli.parse(argc, argv);
 }
 ```
-`g++ -std=c++20 -o some_program some_program.cpp -lclicky`
+
+Usage with `g++`:
+```bash
+g++ -std=c++20 -o some_program some_program.cpp -lclicky
+```
+
+#### Example 2: Program with Usage Message, Arguments, and Options
 
 ```cpp
 #include <clicky/clicky.hpp>
 
 int main(int argc, char* argv[]) {
-   clicky cli("{program} [OPTIONS]"); // usage message, using the {program} variable.
-   
-   cli.add_arguments({
-                     {"argument", "a", true, "This is an argument"},
-                     {"argument2", "b", false, "This is another argument"}
-   });
-   cli.parse(argc,argv)
+    clicky cli("{program} [OPTIONS]"); // usage message, using the {program} variable.
+    
+    cli.add_arguments({
+                     {"argument", "a", "This is an argument", true},
+                     {"argument2", "b", "This is another argument", false}
+    });
+    cli.parse(argc, argv);
 }
 ```
 
-`g++ -std=c++20 -o some_other_program some_other_program.cpp -lclicky`
+Usage with `g++`:
+```bash
+g++ -std=c++20 -o some_other_program some_other_program.cpp -lclicky
+```
 
+Running the program:
 ```
 ./some_other_program --help
 Usage: 
@@ -107,13 +136,10 @@ Arguments:
   --argument, -a     : This is an argument (required)
 ```
 
-That's *pretty much* all that clicky has (for now), I plan to expand the project further, add more things and maybe, just maybe, put it in the official dnf repository, but that's for the future.
-There are some other methods that I haven't mentioned, but they are self-explanatory.
-
-----
+---
 
 ### Contributing
 
 If you think my code is shit, it's because it most likely is, and if you have any advice for me on how to improve my code, please reach out on discord <actually.auth>, or create an issue on this repo.
 
-
+---

--- a/examples/01.cpp
+++ b/examples/01.cpp
@@ -4,24 +4,19 @@
 int main(int argc, char* argv[]) {
     clicky parser;
 
-    // Adding positional arguments
-    parser.add_argument({"input", "entrance"}, {"i"}, true, "Path to the input file");
-    parser.add_argument({"output"}, {"o", "e"}, true, "Path to the output file");
+    parser.add_argument("input", "i", "Path to the input file", true);
+    parser.add_argument("output", "o", "Path to the output file", true);
 
-    // Adding options
-    parser.add_option({"verbose"}, {"v"}, false, "Enable verbose output");
-    parser.add_option({"overwrite"}, {"c"}, false, "Overwrite existing files");
+    parser.add_option("verbose", "v", "Enable verbose output", false);
+    parser.add_option("overwrite", "c", "Overwrite existing files", false);
 
-    // Parsing command-line arguments
     parser.parse(argc, argv);
 
-    // Accessing values
     std::string input = parser.argument("input");
     std::string output = parser.argument("output");
     bool verbose = parser.option("verbose");
     bool overwrite = parser.option("overwrite");
 
-    // Example output
     if (verbose) {
         std::cout << "Input file: " << input << "\n";
         std::cout << "Output file: " << output << "\n";
@@ -32,5 +27,5 @@ int main(int argc, char* argv[]) {
 }
 
 // Usage:
-// ./program --input path/to/file --output path/to/file --verbose --overwrite 
+// ./program --input path/to/file --output path/to/file --verbose --overwrite
 

--- a/examples/02.cpp
+++ b/examples/02.cpp
@@ -1,30 +1,27 @@
-#include "../include/clicky.hpp" 
+#include <clicky/clicky.hpp> 
 #include <iostream>
 
 int main(int argc, char* argv[]) {
     clicky parser("{program} [operation(add, subtract, multiply, divide)] [x] [y]");
 
-    // Adding arguments
-    parser.add_argument({"operation"},{"o"}, true, "Mathematical operation (add, subtract, multiply, divide)");
-    parser.add_argument({"x"}, {""},true, "First number");
-    parser.add_argument({"y"}, {""},true, "Second number");
+    parser.add_argument("operation", "o", "Mathematical operation (add, subtract, multiply, divide)", true);
+    parser.add_argument("x", "", "First number", true);
+    parser.add_argument("y", "", "Second number", true);
 
-    // Adding prefix 
-    parser.set_prefix({"/"}, {"/"}); // new method
-    // clicky::set_prefix() takes two vectors of strings, first being the prefixes for arguments and the second for flags
-    // that means, you can have something like {"/", "-"} for arguments, while flags are kept by the -- default.
-    // If only one string is passed for each, it'll be both for the full argument/flag aswell as its aliases.
+    parser.add_options({
+      {"verbose", "v", "Enable verbose output", false},
+      {"overwrite", "c", "Overwrite existing files", false}
+    });
+    parser.group("options", {"v", "c"});
 
+    parser.set_prefix({"/"}, {"/"});  
 
-    // Parsing arguments
     parser.parse(argc, argv);
 
-    // Retrieving arguments
     std::string operation = parser.argument("operation");
     double num1 = std::stod(parser.argument("x"));
     double num2 = std::stod(parser.argument("y"));
 
-    // Performing operation
     if (operation == "add") {
         std::cout << (num1 + num2) << "\n";
     } else if (operation == "subtract") {
@@ -39,11 +36,12 @@ int main(int argc, char* argv[]) {
         std::cout << (num1 / num2) << "\n";
     } else {
         std::cerr << "Invalid operation: " << operation << "\n";
+        return 1;
     }
 
     return 0;
 }
 
 // Usage:
-// ./calculator --operation add --x 10 --y 10
+// ./calculator /operation add /x 10 /y 10
 

--- a/examples/02.cpp
+++ b/examples/02.cpp
@@ -14,7 +14,6 @@ int main(int argc, char* argv[]) {
     });
     parser.group("options", {"v", "c"});
 
-    parser.set_prefix({"/"}, {"/"});  
 
     parser.parse(argc, argv);
 

--- a/examples/04.cpp
+++ b/examples/04.cpp
@@ -7,14 +7,25 @@ int main(int argc, char* argv[]) {
     cli.add_argument("test", "t", "A test argument", false);
     cli.add_argument("test2", "t2", "Another test argument", false);
 
+    cli.add_options({
+      {"verbose", "v", "Enable verbose output", false},
+      {"overwrite", "c", "Overwrite existing files", false}
+    });
+
+    cli.group("options", {"v", "c"});
+    cli.set_prefix({":"}, {":"});
     cli.parse(argc, argv);
 
     try {
+        // Fetching the values of the arguments
         std::string test = cli.argument("test");
         std::cout << "Test: " << test << "\n";
 
         std::string test2 = cli.argument("test2");
         std::cout << "Test2: " << test2 << "\n";
+
+        std::cout << "Verbose: " << cli.option("verbose") << "\n";
+        std::cout << "Overwrite: " << cli.option("overwrite") << "\n";
 
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << "\n";
@@ -22,4 +33,5 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+
 

--- a/include/clicky.hpp
+++ b/include/clicky.hpp
@@ -1,13 +1,13 @@
-#pragma once 
+#pragma once
 
 // ============= COLORS ==================
 namespace cl_colors {
-    constexpr const char* RESET = "\033[0m";
-    constexpr const char* WHITE = "\033[37m";
-    constexpr const char* BRIGHT_RED = "\033[91m";
-    constexpr const char* BRIGHT_GREEN = "\033[92m";
+    constexpr const char* RESET         = "\033[0m";
+    constexpr const char* WHITE         = "\033[37m";
+    constexpr const char* BRIGHT_RED    = "\033[91m";
+    constexpr const char* BRIGHT_GREEN  = "\033[92m";
     constexpr const char* BRIGHT_YELLOW = "\033[93m";
-    constexpr const char* BRIGHT_CYAN = "\033[96m";
+    constexpr const char* BRIGHT_CYAN   = "\033[96m";
 }
 // =======================================
 
@@ -19,63 +19,73 @@ class clicky {
 public:
     explicit clicky(const std::string& usage = "");
 
-    void add_argument(const std::vector<std::string> args_long, const std::vector<std::string> args_short, bool required, const std::string& description);
-    void add_arguments(const std::vector<std::tuple<std::vector<std::string>, std::vector<std::string>, bool, std::string>>& args);
-  
-    void add_option(const std::vector<std::string> options_long, const std::vector<std::string> options_short = {}, bool default_value = false, const std::string& description = "");
-    void add_options(const std::vector<std::tuple<std::vector<std::string>, std::vector<std::string>, bool, std::string>>& args);
+    // Add individual arguments and options
+    void add_argument(const std::string& arg_name, const std::string& alias, const std::string& description, bool required);
+    void add_arguments(const std::vector<std::tuple<std::string, std::string, std::string, bool>>& args);
 
+    void add_option(const std::string& opt_name, const std::string& alias, const std::string& description, bool default_value);
+    void add_options(const std::vector<std::tuple<std::string, std::string, std::string, bool>>& options);
+
+    // Group options for combined usage like `-xyz`
+    void group(const std::string& group_name, const std::vector<std::string>& option_aliases);
+
+    // Parse input and retrieve values
     void parse(int argc, char* argv[]);
     bool option(const std::string& name) const;
     std::string argument(const std::string& name) const;
     const std::vector<std::string>& positional_arguments() const;
     bool has_argument(const std::string& name) const;
 
+    // Help and configuration
     void print_help() const;
     void set_prefix(const std::vector<std::string>& arg_prefixes, const std::vector<std::string>& option_prefixes = {});
+
+    void enable_grouping();
+    void disable_grouping();
 
 private:
     struct Option {
         bool default_value;
+        std::string alias;
         std::string description;
         bool value;
     };
 
-  struct Argument {
-    bool required;
-    std::string description;
-    std::string value;                 // For single value
-    std::vector<std::string> values;   // For multiple values
-  };
+    struct Argument {
+        bool required;
+        std::string alias;
+        std::string description;
+        std::string value; // For single value
+    };
 
-  std::string usage_;
-    std::vector<std::string> arg_prefixes_ = {"--", "-"}; 
-    std::vector<std::string> option_prefixes_ = {"--", "-"};  
+    // Internal state
+    std::string usage_;
+    std::vector<std::string> arg_prefixes_ = {"--", "-"};
+    std::vector<std::string> option_prefixes_ = {"--", "-"};
+    bool grouping_enabled_ = false;
 
     int argc_;
     char** argv_;
 
-    // TODO: get rid of alias_map_ or replace with something different
+    // Mappings
+    std::unordered_map<std::string, Option*> options_map_;
+    std::unordered_map<std::string, Argument*> args_map_;
     std::unordered_map<std::string, std::string> alias_map_;
+    std::unordered_map<std::string, std::vector<std::string>> option_groups_;
 
-    std::unordered_map<std::string, Option*> options_long_;
-    std::unordered_map<std::string, Option*> options_short_;
-    std::unordered_map<std::string, Argument*> args_long_;
-    std::unordered_map<std::string, Argument*> args_short_;
-
+    // Parsed state
     std::vector<std::string> missing_args_;
     std::vector<std::string> positional_args_;
 
+    // Internal helper methods
     std::string join_values(const std::vector<std::string>& values) const;
     int parse_field(std::string arg);
     bool parse_set(std::string, std::string next_field = "");
-
-    void validate_required_arguments(); 
-    size_t calculate_max_length() const; 
+    void validate_required_arguments();
+    size_t calculate_max_length() const;
 
     template <typename T>
-    void print_items(const std::unordered_map<std::string, T>& items, size_t max_length) const; 
+    void print_items(const std::unordered_map<std::string, T*>& items, size_t max_length) const;
     void print_usage(const std::string& program_name) const;
 };
-
 

--- a/src/clicky.cpp
+++ b/src/clicky.cpp
@@ -7,51 +7,63 @@
 
 // ==== Constructor ====
 clicky::clicky(const std::string& usage) : usage_(usage) {
-  add_option({"help"}, {"h"}, false, "Display this help message");
+  add_option("help", "h", "Display this help message", false);
 }
 
-// ==== Add Argument ====
-void clicky::add_argument(const std::vector<std::string> args_long, const std::vector<std::string> args_short, bool required, const std::string& description) {
-    args_long_[args_long[0]] = new Argument {required, description, "", {}};
 
-    for (size_t i = 1; i < args_long.size(); ++i) {
-        args_long_[args_long[i]] = args_long_[args_long[0]];
-        alias_map_[args_long[i]] = args_long[0];
-    }
-
-    for (size_t i = 0; i < args_short.size(); ++i) {
-        args_short_[args_short[i]] = args_long_[args_long[0]];
-        alias_map_[args_short[i]] = args_long[0];
+// Add a Single Argument
+void clicky::add_argument(const std::string& arg_name, const std::string& alias, const std::string& description, bool required) {
+    auto* arg = new Argument{required, description, "", {}};
+    args_map_[arg_name] = arg;
+    if (!alias.empty()) {
+        alias_map_[alias] = arg_name;
+        args_map_[alias] = arg;
     }
 }
 
-// ==== Add Option ====
-void clicky::add_option(const std::vector<std::string> options_long, const std::vector<std::string> options_short, bool default_value, const std::string& description) {
-    options_long_[options_long[0]] = new Option {default_value, description, false};
-
-    for (size_t i = 1; i < options_long.size(); ++i) {
-        options_long_[options_long[i]] = options_long_[options_long[0]];
-        alias_map_[options_long[i]] = options_long[0];
-    }
-
-    for (size_t i = 0; i < options_short.size(); ++i) {
-        options_short_[options_short[i]] = options_long_[options_long[0]];
-        alias_map_[options_short[i]] = options_long[0];
+// Add Multiple Arguments
+void clicky::add_arguments(const std::vector<std::tuple<std::string, std::string, std::string, bool>>& args) {
+    for (const auto& [arg_name, alias, description, required] : args) {
+        add_argument(arg_name, alias, description, required);
     }
 }
 
-// ==== Add Multiple Arguments ====
-void clicky::add_arguments(const std::vector<std::tuple<std::vector<std::string>, std::vector<std::string>, bool, std::string>>& args) {
-    for (const auto& [args_long, args_short, required, description] : args) {
-        add_argument(args_long, args_short, required, description);
+// Add a Single Option
+void clicky::add_option(const std::string& opt_name, const std::string& alias, const std::string& description, bool default_value) {
+    auto* opt = new Option{default_value, alias,description, false};
+    options_map_[opt_name] = opt;
+    if (!alias.empty()) {
+        alias_map_[alias] = opt_name;
+        options_map_[alias] = opt;
     }
 }
 
-// ==== Add Multiple Options ====
-void clicky::add_options(const std::vector<std::tuple<std::vector<std::string>, std::vector<std::string>, bool, std::string>>& options) {
-    for (const auto& [args_long, args_short, default_value, description] : options) {
-        add_option(args_long, args_short, default_value, description);
+// Add Multiple Options
+void clicky::add_options(const std::vector<std::tuple<std::string, std::string, std::string, bool>>& options) {
+    for (const auto& [opt_name, alias, description, default_value] : options) {
+        add_option(opt_name, alias, description, default_value);
     }
+}
+
+// Group Options
+void clicky::group(const std::string& group_name, const std::vector<std::string>& option_aliases) {
+    option_groups_[group_name] = {};
+    enable_grouping();
+    for (const auto& alias : option_aliases) {
+        if (alias_map_.count(alias)) {
+            option_groups_[group_name].push_back(alias);
+        } else {
+            throw std::invalid_argument("Invalid option alias for grouping: " + alias);
+        }
+    }
+}
+
+void clicky::enable_grouping() {
+    grouping_enabled_ = true;
+}
+
+void clicky::disable_grouping() {
+    grouping_enabled_ = false;
 }
 
 // ==== Set Prefix ====
@@ -62,38 +74,26 @@ void clicky::set_prefix(const std::vector<std::string>& arg_prefixes, const std:
 
 // ==== Parse One Field ====
 int clicky::parse_field(std::string field) {
-    if (options_long_.count(field)) {
-        options_long_[field]->value = true;
+    // Check if the field is an option
+    if (options_map_.count(field)) {
+        options_map_[field]->value = true;
         return 0;
     }
 
+    // Split key-value pairs (e.g., --arg=value)
     size_t value_separator = field.find('=');
-    if (value_separator == std::string::npos) {
-        value_separator = field.find(' ');
-    }
-
     if (value_separator != std::string::npos) {
         std::string key = field.substr(0, value_separator);
         std::string value = field.substr(value_separator + 1);
 
-        if (args_long_.count(key)) {
-            if (value.find(',') != std::string::npos) {
-                std::vector<std::string> values;
-                size_t start = 0, end;
-                while ((end = value.find(',', start)) != std::string::npos) {
-                    values.push_back(value.substr(start, end - start));
-                    start = end + 1;
-                }
-                values.push_back(value.substr(start));
-                args_long_[key]->values = values;
-            } else {
-                args_long_[key]->value = value;
-            }
+        if (args_map_.count(key)) {
+            args_map_[key]->value = value;
         } else {
             std::cerr << "Unknown argument: " << key << '\n';
             return 1;
         }
     } else {
+        // Positional argument
         positional_args_.emplace_back(field);
     }
 
@@ -103,32 +103,63 @@ int clicky::parse_field(std::string field) {
 // ==== Parse A Concatenated Set Of Flags ====
 bool clicky::parse_set(std::string field, std::string next_field) {
     bool next_field_used = false;
-    for (size_t fi = 0; fi < field.length(); ++fi) {
-        std::string expanded;
+    std::cout << field << " " << next_field << '\n';
+    // Check if grouping is enabled
+    if (!grouping_enabled_) {
+        if (alias_map_.count(field)) {
+            std::string expanded = alias_map_[field];
 
-        if (alias_map_.count(std::string(1, field[fi]))) {
-            expanded = alias_map_[std::string(1, field[fi])];
-        } else {
-            std::cerr << "Unknown alias: -" << field[fi] << std::endl;
-            print_usage(argv_[0]);
-            print_help();
-            exit(0);
-        }
-
-        if (args_long_.count(expanded)) {
-            if (fi + 1 >= field.length()) {
-                expanded += "=" + std::string(next_field);
-                next_field_used = true;
+            // Check if it's an argument that requires a value
+            if (args_map_.count(expanded)) {
+                if (!next_field_used && !next_field.empty()) {
+                    args_map_[expanded]->value = next_field;
+                    next_field_used = true;
+                } else {
+                    std::cerr << "Argument --" << field << " requires a value.\n";
+                    exit(1);
+                }
+            } else if (options_map_.count(expanded)) {
+                options_map_[expanded]->value = true;
             } else {
-                expanded += "=" + field.substr(fi + 1);
+                std::cerr << "Unknown option: --" << field << '\n';
+                exit(1);
             }
-            parse_field(expanded);
-            break;
+        } else {
+            std::cout << "Unknown option:" << option_prefixes_[0] << field << '\n';
+            exit(1);
         }
-        parse_field(expanded);
+    } else {
+        // If grouping is enabled, process each alias individually
+        for (char alias : field) {
+            std::string alias_str(1, alias);
+
+            if (alias_map_.count(alias_str)) {
+                std::string expanded = alias_map_[alias_str];
+
+                if (args_map_.count(expanded)) {
+                    if (!next_field_used && !next_field.empty()) {
+                        args_map_[expanded]->value = next_field;
+                        next_field_used = true;
+                    } else {
+                        std::cerr << "Argument -" << alias << " requires a value.\n";
+                        exit(1);
+                    }
+                } else if (options_map_.count(expanded)) {
+                    options_map_[expanded]->value = true;
+                } else {
+                    std::cerr << "Unknown alias: -" << alias << std::endl;
+                    exit(1);
+                }
+            } else {
+                std::cerr << "Unknown alias: -" << alias << std::endl;
+                exit(1);
+            }
+        }
     }
+
     return next_field_used;
 }
+
 
 // ==== Parse Command-Line Arguments ====
 void clicky::parse(int argc, char* argv[]) {
@@ -139,39 +170,39 @@ void clicky::parse(int argc, char* argv[]) {
         std::string field = argv[i];
         bool is_alias = false;
 
-        if (!option_prefixes_.empty() && field.starts_with(option_prefixes_[0])) {
-            field = field.substr(option_prefixes_[0].length());
-        } else if (!arg_prefixes_.empty() && field.starts_with(arg_prefixes_[0])) {
-            field = field.substr(arg_prefixes_[0].length());
-        } else is_alias = true;
+        // Remove prefixes for options and arguments
+        for (const auto& prefix : option_prefixes_) {
+            if (field.starts_with(prefix)) {
+                field = field.substr(prefix.length());
+                break;
+            }
+        }
+        for (const auto& prefix : arg_prefixes_) {
+            if (field.starts_with(prefix)) {
+                field = field.substr(prefix.length());
+                break;
+            }
+        }
 
-        if (!is_alias) {
-            if (args_long_.count(field)) {
+        // Check for concatenated flags (e.g., -xyz)
+        if (field.length() > 1 && !args_map_.count(field)) {
+            is_alias = true;
+        }
+
+        if (is_alias) {
+            if (parse_set(field, (i + 1 < argc) ? argv[i + 1] : "")) {
+                ++i;
+            }
+        } else {
+            // Check if the next field is a value
+            if (args_map_.count(field)) {
                 if (i + 1 < argc &&
                     !std::string(argv[i + 1]).starts_with(option_prefixes_[0]) &&
                     !std::string(argv[i + 1]).starts_with(arg_prefixes_[0])) {
                     field += "=" + std::string(argv[++i]);
-                } else if (args_long_[field]->required) {
-                    missing_args_.push_back(field);
                 }
             }
             parse_field(field);
-        } else {
-            if (!option_prefixes_.empty() && field.starts_with(option_prefixes_[1])) {
-                field = field.substr(option_prefixes_[1].length());
-            } else if (!arg_prefixes_.empty() && field.starts_with(arg_prefixes_[1])) {
-                field = field.substr(arg_prefixes_[1].length());
-            }
-
-            if (
-                parse_set(field,
-                          i + 1 < argc_ &&
-                              !std::string(argv_[i + 1]).starts_with(option_prefixes_[0]) &&
-                              !std::string(argv_[i + 1]).starts_with(option_prefixes_[1]) &&
-                              !std::string(argv_[i + 1]).starts_with(arg_prefixes_[0]) &&
-                              !std::string(argv_[i + 1]).starts_with(arg_prefixes_[1])
-                              ? argv_[i + 1] : ""))
-                ++i;
         }
     }
 
@@ -184,44 +215,46 @@ void clicky::parse(int argc, char* argv[]) {
     validate_required_arguments();
 }
 
+
+// ==== Validate Required Arguments ====
 void clicky::validate_required_arguments() {
-  std::stringstream error_message;
+    std::stringstream error_message;
 
-  for (const auto& [name, arg] : args_long_) {
-    if (arg->required && arg->value.empty()) {
-      missing_args_.push_back(name);
-      error_message << (cl_colors::BRIGHT_CYAN + name + cl_colors::RESET)
-                    << " : " << arg->description << " [required]\n";
+    for (const auto& [name, arg] : args_map_) {
+        if (arg->required && arg->value.empty()) {
+            missing_args_.push_back(name);
+            error_message << cl_colors::BRIGHT_CYAN << name << cl_colors::RESET
+                          << " : " << arg->description << " [required]\n";
+        }
     }
-  }
 
-  if (!missing_args_.empty()) {
-    std::cerr << cl_colors::BRIGHT_RED
-              << "Missing required argument(s):\n"
-              << cl_colors::RESET
-              << error_message.str();
-    exit(1);
-  }
+    if (!missing_args_.empty()) {
+        std::cerr << cl_colors::BRIGHT_RED
+                  << "Missing required argument(s):\n"
+                  << cl_colors::RESET
+                  << error_message.str();
+        exit(1);
+    }
 }
 
 // ==== Option Value ====
 bool clicky::option(const std::string& name) const {
-  auto it = options_long_.find(name);
-  return it != options_long_.end() && it->second->value;
+    auto it = options_map_.find(name);
+    return it != options_map_.end() && it->second->value;
 }
 
 // ==== Argument Value ====
 std::string clicky::argument(const std::string& name) const {
-  auto it = args_long_.find(name);
-  if (it == args_long_.end() || it->second->value.empty()) {
-    throw std::out_of_range("Argument '" + name + "' is missing or not provided.");
-  }
-  return it->second->value;
+    auto it = args_map_.find(name);
+    if (it == args_map_.end() || it->second->value.empty()) {
+        throw std::out_of_range("Argument '" + name + "' is missing or not provided.");
+    }
+    return it->second->value;
 }
 
 // ==== Has Argument ====
 bool clicky::has_argument(const std::string& name) const {
-    return args_long_.count(name) && !args_long_.at(name)->value.empty();
+    return args_map_.count(name) && !args_map_.at(name)->value.empty();
 }
 
 // ==== Positional Arguments ====
@@ -239,91 +272,65 @@ std::string clicky::join_values(const std::vector<std::string>& values) const {
 
 // ==== Print Help Message ====
 void clicky::print_help() const {
+    size_t max_length = calculate_max_length();
+
+    std::cout << cl_colors::BRIGHT_YELLOW << "Options:\n" << cl_colors::RESET;
+    print_items(options_map_, max_length);
+
+    std::cout << "\n" << cl_colors::BRIGHT_YELLOW << "Arguments:\n" << cl_colors::RESET;
+    print_items(args_map_, max_length);
+}
+
+
+// ==== Print Items Helper Function ====
+template <typename T>
+void clicky::print_items(const std::unordered_map<std::string, T*>& items, size_t max_length) const {
+    for (const auto& [name, item] : items) {
+        std::cout << "  " << cl_colors::BRIGHT_CYAN << "--" << name;
+
+        if (!item->alias.empty()) {
+            std::cout << cl_colors::BRIGHT_GREEN << ", -" << item->alias;
+        }
+
+        size_t current_length = name.length() + (item->alias.empty() ? 0 : item->alias.length() + 4);
+        size_t padding = max_length - current_length + 4;
+
+        std::cout << std::string(padding, ' ') << cl_colors::RESET << ": "
+                  << cl_colors::WHITE << item->description << cl_colors::RESET;
+
+        if constexpr (std::is_same_v<T, Option>) {
+            std::cout << " (default: "
+                      << (item->default_value ? (cl_colors::BRIGHT_GREEN + std::string("true")) : (cl_colors::BRIGHT_RED + std::string("false")))
+                      << cl_colors::RESET << ")";
+        } else { // Assuming it's an Argument
+            std::cout << (item->required ? cl_colors::BRIGHT_RED + std::string(" (required)") : cl_colors::BRIGHT_GREEN + std::string(" (optional)"))
+                      << cl_colors::RESET;
+        }
+
+        std::cout << '\n';
+    }
+}
+
+// ==== Calculate Maximum Length ====
+size_t clicky::calculate_max_length() const {
     size_t max_length = 0;
 
-    // Lambda to calculate maximum length of arguments/options for formatting
-    auto calculate_max_length = [&](const auto& map) {
+    auto update_max_length = [&](const auto& map) {
         for (const auto& [name, item] : map) {
             size_t length = name.length();
-            for (const auto& prefix : option_prefixes_) {
-                length = std::max(length, name.length() + prefix.length() + 2); // Account for prefix and ", "
+            if (!item->alias.empty()) {
+                length += item->alias.length() + 4; // Account for ", -"
             }
             max_length = std::max(max_length, length);
         }
     };
 
-    calculate_max_length(options_long_);
-    calculate_max_length(args_long_);
+    update_max_length(options_map_);
+    update_max_length(args_map_);
 
-    std::cout << cl_colors::BRIGHT_YELLOW << "Options:\n" << cl_colors::RESET;
-    for (const auto& [name, option] : options_long_) {
-        for (const auto& prefix : option_prefixes_) {
-            std::cout << cl_colors::BRIGHT_CYAN << "  " << prefix << name;
-            //if (!option.alias.empty()) {
-                //std::cout << cl_colors::BRIGHT_GREEN << ", " << prefix << option.alias;
-            //}
-
-            size_t current_length = name.length();
-            size_t padding = max_length - current_length + 4;
-            std::cout << std::string(padding, ' ') << cl_colors::RESET << ": "
-                      << cl_colors::WHITE << option->description << cl_colors::RESET
-                      << " (default: "
-                      << (option->default_value ? (cl_colors::BRIGHT_GREEN + std::string("true")) : (cl_colors::BRIGHT_RED + std::string("false")))
-                      << cl_colors::RESET << ")\n";
-        }
-    }
-
-    std::cout << "\n" << cl_colors::BRIGHT_YELLOW << "Arguments:\n" << cl_colors::RESET;
-    for (const auto& [name, arg] : args_long_) {
-        for (const auto& prefix : arg_prefixes_) {
-            std::cout << cl_colors::BRIGHT_CYAN << "  " << prefix << name;
-            //if (!arg.alias.empty()) {
-                //std::cout << cl_colors::BRIGHT_GREEN << ", " << prefix << arg.alias;
-            //}
-
-            size_t current_length = name.length();
-            size_t padding = max_length - current_length + 4;
-            std::cout << std::string(padding, ' ') << cl_colors::RESET << ": "
-                      << cl_colors::WHITE << arg->description << cl_colors::RESET
-                      << (arg->required ? (cl_colors::BRIGHT_RED + std::string(" (required)")) : (cl_colors::BRIGHT_GREEN + std::string(" (optional)")))
-                      << cl_colors::RESET << '\n';
-        }
-    }
+    return max_length;
 }
 
-template <typename T>
-void clicky::print_items(const std::unordered_map<std::string, T>& items, size_t max_length) const {
-  for (const auto& [name, item] : items) {
-    std::cout << "  --" << name;
-    if (!item.alias.empty()) std::cout << ", -" << item.alias;
-
-    size_t current_length = name.length() + (item.alias.empty() ? 0 : item.alias.length() + 4);
-    size_t padding = max_length - current_length + 4;
-    std::cout << std::string(padding, ' ') << ": " << item.description;
-
-    if constexpr (std::is_same_v<T, Option>) {
-      std::cout << " (default: " << (item.default_value ? "true" : "false") << ")";
-    } else {
-      std::cout << (item.required ? " (required)" : " (optional)");
-    }
-    std::cout << '\n';
-  }
-}
-
-size_t clicky::calculate_max_length() const {
-  size_t max_length = 0;
-
-  auto update_max_length = [&](const auto& map) {
-    for (const auto& [name, item] : map) {
-      size_t length = name.length();
-      max_length = std::max(max_length, length);
-    }
-  };
-
-  update_max_length(options_long_);
-  update_max_length(args_long_);
-  return max_length;
-}
 
 void clicky::print_usage(const std::string& program_name) const {
     if (!usage_.empty()) {
@@ -332,3 +339,6 @@ void clicky::print_usage(const std::string& program_name) const {
                   << cl_colors::WHITE << "  " << formatted_usage << cl_colors::RESET << "\n\n";
     }
 }
+
+
+


### PR DESCRIPTION
The implementation of the parsing logic for command-line arguments had an issue where long-form options (e.g., --help) were incorrectly treated as concatenated sets of single-character flags (e.g., -h, -e, -l, -p). This led to errors when encountering valid long-form options (and arguments' aliases) that didn't align with the expected format for aliases or grouped flags.



-- praise the Omnissiah